### PR TITLE
swing concurrency fixes

### DIFF
--- a/src/main/java/com/irsdl/burp/generic/BurpTitleAndIcon.java
+++ b/src/main/java/com/irsdl/burp/generic/BurpTitleAndIcon.java
@@ -33,33 +33,29 @@ public class BurpTitleAndIcon {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new Thread(() -> {
-                    sharedParameters.get_mainFrame().setTitle(title);
-                    sharedParameters.printDebugMessage("Burp Suite title was changed to: " + title);
-                }).start();
+                sharedParameters.get_mainFrame().setTitle(title);
+                sharedParameters.printDebugMessage("Burp Suite title was changed to: " + title);
             }
         });
     }
 
     private static void setIcon(BurpExtensionSharedParameters sharedParameters, Image img) {
-        if(img!=null) {
+        if (img != null) {
             SwingUtilities.invokeLater(new Runnable() {
                 @Override
                 public void run() {
-                    new Thread(() -> {
-                        java.util.List<Image> iconList = new ArrayList<Image>();
-                        iconList.add(img);
+                    java.util.List<Image> iconList = new ArrayList<Image>();
+                    iconList.add(img);
                         /*
                         for (Frame frame : Frame.getFrames()) {
                             frame.setIconImages(iconList);
                         }
                         */
-                        for (Window window : Window.getWindows()) {
-                            window.setIconImages(iconList);
-                        }
-                        //sharedParameters.get_mainFrame().setIconImage(img);
-                        sharedParameters.printDebugMessage("Burp Suite icon has been updated");
-                    }).start();
+                    for (Window window : Window.getWindows()) {
+                        window.setIconImages(iconList);
+                    }
+                    //sharedParameters.get_mainFrame().setIconImage(img);
+                    sharedParameters.printDebugMessage("Burp Suite icon has been updated");
                 }
             });
         }

--- a/src/main/java/com/irsdl/burp/generic/BurpUITools.java
+++ b/src/main/java/com/irsdl/burp/generic/BurpUITools.java
@@ -113,20 +113,18 @@ public class BurpUITools {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new Thread(() -> {
-                    for (int i = 0; i < menuBar.getMenuCount(); i++) {
-                        JMenuItem item = menuBar.getMenu(i);
-                        if (item.getText().trim().equalsIgnoreCase(toolbarName.trim())) {
-                            menuBar.remove(i);
-                            // break; // we may have more than one menu so this line needs to be commented
-                        }
+                for (int i = 0; i < menuBar.getMenuCount(); i++) {
+                    JMenuItem item = menuBar.getMenu(i);
+                    if (item.getText().trim().equalsIgnoreCase(toolbarName.trim())) {
+                        menuBar.remove(i);
+                        // break; // we may have more than one menu so this line needs to be commented
                     }
+                }
 
-                    if (repaintUI) {
-                        menuBar.revalidate();
-                        menuBar.repaint();
-                    }
-                }).start();
+                if (repaintUI) {
+                    menuBar.revalidate();
+                    menuBar.repaint();
+                }
             }
         });
     }

--- a/src/main/java/com/irsdl/burp/sharpener/SharpenerBurpExtender.java
+++ b/src/main/java/com/irsdl/burp/sharpener/SharpenerBurpExtender.java
@@ -68,9 +68,7 @@ public class SharpenerBurpExtender implements IBurpExtender, ITab, IExtensionSta
             public void run() {
                 dummyPanel = new JPanel(); //Will be removed shortly after it's added, doesn't need to be anything special at the moment!
                 callbacks.addSuiteTab(SharpenerBurpExtender.this);
-                new Thread(() -> {
-                    load(false);
-                }).start();
+                load(false);
             }
         });
 
@@ -197,11 +195,16 @@ public class SharpenerBurpExtender implements IBurpExtender, ITab, IExtensionSta
                                 new java.util.TimerTask() {
                                     @Override
                                     public void run() {
-                                        sharedParameters.printDebugMessage("lookAndFeelPropChangeListener");
-                                        sharedParameters.defaultSubTabObject = null;
-                                        UIHelper.showWarningMessage("Due to a major UI change, the " + sharedParameters.extensionName + " extension needs to be unload. Please load it manually.", sharedParameters.get_mainFrame());
-                                        BurpUITools.switchToMainTab("Extender", sharedParameters.get_rootTabbedPane());
-                                        sharedParameters.callbacks.unloadExtension();
+                                        SwingUtilities.invokeLater(new Runnable() {
+                                            @Override
+                                            public void run() {
+                                                sharedParameters.printDebugMessage("lookAndFeelPropChangeListener");
+                                                sharedParameters.defaultSubTabObject = null;
+                                                UIHelper.showWarningMessage("Due to a major UI change, the " + sharedParameters.extensionName + " extension needs to be unload. Please load it manually.", sharedParameters.get_mainFrame());
+                                                BurpUITools.switchToMainTab("Extender", sharedParameters.get_rootTabbedPane());
+                                                sharedParameters.callbacks.unloadExtension();
+                                            }
+                                        });
                                     }
                                 },
                                 2000

--- a/src/main/java/com/irsdl/burp/sharpener/uiModifiers/subTabs/SubTabSettings.java
+++ b/src/main/java/com/irsdl/burp/sharpener/uiModifiers/subTabs/SubTabSettings.java
@@ -57,7 +57,7 @@ public class SubTabSettings extends StandardSettings {
             PreferenceObject preferenceObject_isTabFixedPositionUI_Tab;
             if (sharedParameters.burpMajorVersion > 2022 || (sharedParameters.burpMajorVersion == 2022 && sharedParameters.burpMinorVersion >= 3)) {
                 preferenceObject_isTabFixedPositionUI_Tab = new PreferenceObject("isTabFixedPosition_" + tool, Boolean.TYPE, true, Preferences.Visibility.GLOBAL);
-            }else{
+            } else {
                 preferenceObject_isTabFixedPositionUI_Tab = new PreferenceObject("isTabFixedPosition_" + tool, Boolean.TYPE, false, Preferences.Visibility.GLOBAL);
             }
             preferenceObjectCollection.add(preferenceObject_isTabFixedPositionUI_Tab);
@@ -83,47 +83,45 @@ public class SubTabSettings extends StandardSettings {
                 SwingUtilities.invokeLater(new Runnable() {
                     @Override
                     public void run() {
-                        new Thread(() -> {
-                            if (sharedParameters.preferences.safeGetBooleanSetting("isScrollable_" + tool)) {
-                                try{
-                                    // this causes error on Burp start so we need to run it with a delay
-                                    new java.util.Timer().schedule(
-                                            new java.util.TimerTask() {
-                                                @Override
-                                                public void run() {
-                                                    sharedParameters.get_toolTabbedPane(tool).setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
-                                                }
-                                            },
-                                            2000 // 2 seconds-delay to ensure all has been settled!
-                                    );
-                                }catch(Exception e){
-                                    sharedParameters.printDebugMessage("Error when applying the isScrollable setting, disabling the setting...");
-                                    sharedParameters.preferences.setSetting("isScrollable_" + tool,false);
-                                }
+                        if (sharedParameters.preferences.safeGetBooleanSetting("isScrollable_" + tool)) {
+                            try {
+                                // this causes error on Burp start so we need to run it with a delay
+                                new java.util.Timer().schedule(
+                                        new java.util.TimerTask() {
+                                            @Override
+                                            public void run() {
+                                                sharedParameters.get_toolTabbedPane(tool).setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
+                                            }
+                                        },
+                                        2000 // 2 seconds-delay to ensure all has been settled!
+                                );
+                            } catch (Exception e) {
+                                sharedParameters.printDebugMessage("Error when applying the isScrollable setting, disabling the setting...");
+                                sharedParameters.preferences.setSetting("isScrollable_" + tool, false);
                             }
+                        }
 
-                            if (sharedParameters.preferences.safeGetBooleanSetting("mouseWheelToScroll_" + tool)) {
-                                try{
-                                    SubTabActions.addMouseWheelToJTabbedPane(sharedParameters, tool, false);
-                                }catch(Exception e){
-                                    sharedParameters.printDebugMessage("Error when applying the Mouse Wheel setting, disabling the setting...");
-                                    sharedParameters.preferences.setSetting("mouseWheelToScroll_" + tool,false);
-                                }
+                        if (sharedParameters.preferences.safeGetBooleanSetting("mouseWheelToScroll_" + tool)) {
+                            try {
+                                SubTabActions.addMouseWheelToJTabbedPane(sharedParameters, tool, false);
+                            } catch (Exception e) {
+                                sharedParameters.printDebugMessage("Error when applying the Mouse Wheel setting, disabling the setting...");
+                                sharedParameters.preferences.setSetting("mouseWheelToScroll_" + tool, false);
                             }
+                        }
 
-                            if(sharedParameters.originalSubTabbedPaneUI.get(tool) == null && sharedParameters.get_toolTabbedPane(tool) != null)
-                                sharedParameters.originalSubTabbedPaneUI.put(tool,sharedParameters.get_toolTabbedPane(tool).getUI());
+                        if (sharedParameters.originalSubTabbedPaneUI.get(tool) == null && sharedParameters.get_toolTabbedPane(tool) != null)
+                            sharedParameters.originalSubTabbedPaneUI.put(tool, sharedParameters.get_toolTabbedPane(tool).getUI());
 
-                            if (sharedParameters.originalSubTabbedPaneUI.get(tool) == null &&
-                                    sharedParameters.get_toolTabbedPane(tool) != null) {
-                                sharedParameters.originalSubTabbedPaneUI.put(tool,
-                                        sharedParameters.get_toolTabbedPane(tool).getUI());
-                            }
+                        if (sharedParameters.originalSubTabbedPaneUI.get(tool) == null &&
+                                sharedParameters.get_toolTabbedPane(tool) != null) {
+                            sharedParameters.originalSubTabbedPaneUI.put(tool,
+                                    sharedParameters.get_toolTabbedPane(tool).getUI());
+                        }
 
-                            if(sharedParameters.get_toolTabbedPane(tool)!=null)
-                                sharedParameters.get_toolTabbedPane(tool).setUI(SubTabCustomTabbedPaneUI.getUI(sharedParameters, tool));
+                        if (sharedParameters.get_toolTabbedPane(tool) != null)
+                            sharedParameters.get_toolTabbedPane(tool).setUI(SubTabCustomTabbedPaneUI.getUI(sharedParameters, tool));
 
-                        }).start();
                     }
                 });
             }
@@ -214,7 +212,7 @@ public class SubTabSettings extends StandardSettings {
                         }
                     }
                     // this for dotdotdot tab!
-                    SubTabContainerHandler tempDotDotDotSubTabContainerHandler = new SubTabContainerHandler(sharedParameters, subTabbedPane, subTabbedPane.getTabCount()-1, true);
+                    SubTabContainerHandler tempDotDotDotSubTabContainerHandler = new SubTabContainerHandler(sharedParameters, subTabbedPane, subTabbedPane.getTabCount() - 1, true);
                     if (tempDotDotDotSubTabContainerHandler != null && !updatedSubTabContainerHandlers.contains(tempDotDotDotSubTabContainerHandler)) {
                         // we have a new tab
                         tempDotDotDotSubTabContainerHandler.addSubTabWatcher();
@@ -238,7 +236,7 @@ public class SubTabSettings extends StandardSettings {
             }
 
             if (sharedParameters.preferences.safeGetBooleanSetting("mouseWheelToScroll_" + tool)) {
-                SubTabActions.removeMouseWheelFromJTabbedPane(sharedParameters,tool, true);
+                SubTabActions.removeMouseWheelFromJTabbedPane(sharedParameters, tool, true);
             }
 
             if (sharedParameters.supportedTools_SubTabs.get(tool) != null) {
@@ -246,7 +244,7 @@ public class SubTabSettings extends StandardSettings {
                 for (SubTabContainerHandler subTabContainerHandler : subTabContainerHandlers) {
                     if (subTabContainerHandler.isValid()) {
                         // Step1 of filter removal
-                        if(sharedParameters.isFiltered(tool))
+                        if (sharedParameters.isFiltered(tool))
                             subTabContainerHandler.setVisible(true);
                         subTabContainerHandler.removeIcon(true);
                         subTabContainerHandler.removeSubTabWatcher();
@@ -255,7 +253,7 @@ public class SubTabSettings extends StandardSettings {
                 }
 
                 // Step2 of filter and Fixed Tab Position removal
-                if(sharedParameters.originalSubTabbedPaneUI.get(tool) != null) {
+                if (sharedParameters.originalSubTabbedPaneUI.get(tool) != null) {
                     //sharedParameters.get_toolTabbedPane(tool).setUI(sharedParameters.get_toolTabbedPane(tool).getUI()); // replaced by updateUI()
                     sharedParameters.get_toolTabbedPane(tool).updateUI();
                     sharedParameters.get_toolTabbedPane(tool).revalidate();

--- a/src/main/java/com/irsdl/burp/sharpener/uiModifiers/subTabs/SubTabWatcher.java
+++ b/src/main/java/com/irsdl/burp/sharpener/uiModifiers/subTabs/SubTabWatcher.java
@@ -28,33 +28,33 @@ public class SubTabWatcher implements ContainerListener {
     private boolean _isUpdateInProgress = false;
     private ArrayList<BurpUITools.MainTabs> accessibleTabs;
     private boolean _isShortcutEnabled = true;
-    public HashMap<String,String> subTabsShortcutMappings = new HashMap<String, String>() {{
-        put("control ENTER","ShowMenu");
-        put("control shift ENTER","ShowMenu");
-        put("DOWN","ShowMenu");
-        put("control shift F","FindTabs");
-        put("F3","NextFind");
-        put("control F3","NextFind");
-        put("shift F3","PreviousFind");
-        put("control shift F3","PreviousFind");
-        put("HOME","FirstTab");
-        put("END","LastTab");
-        put("control shift HOME","FirstTab");
-        put("control shift END","LastTab");
-        put("LEFT","PreviousTab");
-        put("RIGHT","NextTab");
-        put("control shift LEFT","PreviousTab");
-        put("control shift RIGHT","NextTab");
-        put("alt LEFT","PreviouslySelectedTab");
-        put("alt RIGHT","NextlySelectedTab");
-        put("control alt LEFT","PreviouslySelectedTab");
-        put("control alt RIGHT","NextlySelectedTab");
-        put("control C","CopyTitle");
-        put("control shift C","CopyTitle");
-        put("control V","PasteTitle");
-        put("control shift V","PasteTitle");
-        put("F2","RenameTitle");
-        put("control F2","RenameTitle");
+    public HashMap<String, String> subTabsShortcutMappings = new HashMap<String, String>() {{
+        put("control ENTER", "ShowMenu");
+        put("control shift ENTER", "ShowMenu");
+        put("DOWN", "ShowMenu");
+        put("control shift F", "FindTabs");
+        put("F3", "NextFind");
+        put("control F3", "NextFind");
+        put("shift F3", "PreviousFind");
+        put("control shift F3", "PreviousFind");
+        put("HOME", "FirstTab");
+        put("END", "LastTab");
+        put("control shift HOME", "FirstTab");
+        put("control shift END", "LastTab");
+        put("LEFT", "PreviousTab");
+        put("RIGHT", "NextTab");
+        put("control shift LEFT", "PreviousTab");
+        put("control shift RIGHT", "NextTab");
+        put("alt LEFT", "PreviouslySelectedTab");
+        put("alt RIGHT", "NextlySelectedTab");
+        put("control alt LEFT", "PreviouslySelectedTab");
+        put("control alt RIGHT", "NextlySelectedTab");
+        put("control C", "CopyTitle");
+        put("control shift C", "CopyTitle");
+        put("control V", "PasteTitle");
+        put("control shift V", "PasteTitle");
+        put("F2", "RenameTitle");
+        put("control F2", "RenameTitle");
     }};
 
     public SubTabWatcher(SharpenerSharedParameters sharedParameters, Consumer<MouseEvent> mouseEventConsumer) {
@@ -122,11 +122,11 @@ public class SubTabWatcher implements ContainerListener {
         // Burp has changed something in the UI so we need this if condition to support older versions
         Component targetComponent;
 
-        if(tabComponent.getMouseListeners().length > 0){
+        if (tabComponent.getMouseListeners().length > 0) {
             targetComponent = tabComponent;
-        }else{
+        } else {
             //tabComponent.getComponentAt(0,0).addMouseListener(new SubTabClickHandler(this.mouseEventConsumer));
-            targetComponent = tabComponent.getComponentAt(0,0);
+            targetComponent = tabComponent.getComponentAt(0, 0);
         }
 
         // this is a dirty hack to keep the colours as they go black after drag and drop!
@@ -151,10 +151,15 @@ public class SubTabWatcher implements ContainerListener {
                             new TimerTask() {
                                 @Override
                                 public void run() {
-                                    //sharedParameters.allSettings.subTabSettings.updateSubTabsUI(toolName);
-                                    sharedParameters.allSettings.subTabSettings.loadSettings(toolName);
-                                    sharedParameters.allSettings.subTabSettings.saveSettings(toolName);
-                                    set_isUpdateInProgress(false);
+                                    SwingUtilities.invokeLater(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            //sharedParameters.allSettings.subTabSettings.updateSubTabsUI(toolName);
+                                            sharedParameters.allSettings.subTabSettings.loadSettings(toolName);
+                                            sharedParameters.allSettings.subTabSettings.saveSettings(toolName);
+                                            set_isUpdateInProgress(false);
+                                        }
+                                    });
                                 }
                             },
                             delay
@@ -171,18 +176,21 @@ public class SubTabWatcher implements ContainerListener {
 
         if (subTabbedPane != null) {
             addSubTabsListener(subTabbedPane, toolName);
-        }else{
+        } else {
             // when Burp Suite is loaded for the first time, Repeater and Intruder tabs are empty in the latest versions rather than having one tab
             // This is to address the issue of component change when the first tab is being created
             targetComponent.addComponentListener(new ComponentListener() {
                 @Override
-                public void componentResized(ComponentEvent e) {}
+                public void componentResized(ComponentEvent e) {
+                }
 
                 @Override
-                public void componentMoved(ComponentEvent e) {}
+                public void componentMoved(ComponentEvent e) {
+                }
 
                 @Override
-                public void componentShown(ComponentEvent e) {}
+                public void componentShown(ComponentEvent e) {
+                }
 
                 @Override
                 public void componentHidden(ComponentEvent e) {
@@ -190,20 +198,25 @@ public class SubTabWatcher implements ContainerListener {
                             new java.util.TimerTask() {
                                 @Override
                                 public void run() {
-                                    // This will be triggered when Burp creates items in Repeater or Intruder
-                                    BurpUITools.MainTabs toolName = BurpUITools.getMainTabsObjFromString(sharedParameters.get_rootTabbedPane().getTitleAt(sharedParameters.get_rootTabbedPane().indexOfComponent(((Component) e.getSource()).getParent())));
-                                    JTabbedPane subTabbedPane = sharedParameters.get_toolTabbedPane(toolName);
-                                    if (subTabbedPane != null) {
-                                        if(subTabbedPane.getPropertyChangeListeners("tabPropertyChangeListener").length==0)
-                                            subTabbedPane.addPropertyChangeListener("indexForTabComponent", tabPropertyChangeListener);
+                                    SwingUtilities.invokeLater(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            // This will be triggered when Burp creates items in Repeater or Intruder
+                                            BurpUITools.MainTabs toolName = BurpUITools.getMainTabsObjFromString(sharedParameters.get_rootTabbedPane().getTitleAt(sharedParameters.get_rootTabbedPane().indexOfComponent(((Component) e.getSource()).getParent())));
+                                            JTabbedPane subTabbedPane = sharedParameters.get_toolTabbedPane(toolName);
+                                            if (subTabbedPane != null) {
+                                                if (subTabbedPane.getPropertyChangeListeners("tabPropertyChangeListener").length == 0)
+                                                    subTabbedPane.addPropertyChangeListener("indexForTabComponent", tabPropertyChangeListener);
 
-                                        addSubTabsListener(subTabbedPane, toolName);
+                                                addSubTabsListener(subTabbedPane, toolName);
 
-                                        // as there is no other getComponentListeners by default, we can remove them all
-                                        for (ComponentListener cl : subTabbedPane.getComponentListeners()) {
-                                            subTabbedPane.removeComponentListener(cl);
+                                                // as there is no other getComponentListeners by default, we can remove them all
+                                                for (ComponentListener cl : subTabbedPane.getComponentListeners()) {
+                                                    subTabbedPane.removeComponentListener(cl);
+                                                }
+                                            }
                                         }
-                                    }
+                                    });
                                 }
                             },
                             5000 // 5 seconds delay just in case Burp is very slow on the device
@@ -219,8 +232,8 @@ public class SubTabWatcher implements ContainerListener {
         removeListenerFromTabbedPanels((JTabbedPane) e.getContainer(), e.getChild());
     }
 
-    private void addSubTabsListener(JTabbedPane subTabbedPane, BurpUITools.MainTabs toolName){
-        if(sharedParameters.allSubTabContainerHandlers.get(toolName) == null || sharedParameters.allSubTabContainerHandlers.get(toolName).size() != subTabbedPane.getTabCount()-1){
+    private void addSubTabsListener(JTabbedPane subTabbedPane, BurpUITools.MainTabs toolName) {
+        if (sharedParameters.allSubTabContainerHandlers.get(toolName) == null || sharedParameters.allSubTabContainerHandlers.get(toolName).size() != subTabbedPane.getTabCount() - 1) {
             ArrayList<SubTabContainerHandler> subTabContainerHandlers = new ArrayList<>();
             for (Component subTabComponent : subTabbedPane.getComponents()) {
                 int subTabIndex = subTabbedPane.indexOfComponent(subTabComponent);
@@ -231,7 +244,7 @@ public class SubTabWatcher implements ContainerListener {
             }
 
             // this for dotdotdot tab!
-            SubTabContainerHandler tempDotDotDotSubTabContainerHandler = new SubTabContainerHandler(sharedParameters, subTabbedPane, subTabbedPane.getTabCount()-1, true);
+            SubTabContainerHandler tempDotDotDotSubTabContainerHandler = new SubTabContainerHandler(sharedParameters, subTabbedPane, subTabbedPane.getTabCount() - 1, true);
             if (tempDotDotDotSubTabContainerHandler != null && !subTabContainerHandlers.contains(tempDotDotDotSubTabContainerHandler)) {
                 // we have a new tab
                 tempDotDotDotSubTabContainerHandler.addSubTabWatcher();
@@ -244,9 +257,9 @@ public class SubTabWatcher implements ContainerListener {
         subTabbedPane.addMouseListener(new MouseAdapterExtensionHandler(mouseEventConsumer, MouseEvent.MOUSE_RELEASED));
 
         //Defining shortcuts for search in tab titles: ctrl+shift+f , F3, shift+F3
-        if(_isShortcutEnabled) {
+        if (_isShortcutEnabled) {
             clearInputMap(subTabbedPane);
-            subTabsShortcutMappings.forEach((k,v) -> subTabbedPane.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
+            subTabsShortcutMappings.forEach((k, v) -> subTabbedPane.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
                     KeyStroke.getKeyStroke(k), v));
 
             subTabbedPane.getActionMap().put("ShowMenu", new AbstractAction() {
@@ -348,11 +361,11 @@ public class SubTabWatcher implements ContainerListener {
         // Burp has changed something in the UI so we need this if condition to support older versions
         JComponent targetComponent;
 
-        if(tabComponent.getMouseListeners().length > 0){
+        if (tabComponent.getMouseListeners().length > 0) {
             targetComponent = (JComponent) tabComponent;
-        }else{
+        } else {
             //tabComponent.getComponentAt(0,0).addMouseListener(new SubTabClickHandler(this.mouseEventConsumer));
-            targetComponent = (JComponent) tabComponent.getComponentAt(0,0);
+            targetComponent = (JComponent) tabComponent.getComponentAt(0, 0);
         }
 
         // as there is no other PropertyChangeListener with propertyName of "indexForTabComponent" by default, we can remove them all
@@ -378,15 +391,16 @@ public class SubTabWatcher implements ContainerListener {
         }
 
         // There is no bindings on these items so it can be cleared
-        if(_isShortcutEnabled) {
+        if (_isShortcutEnabled) {
             clearInputMap(targetComponent);
         }
     }
 
-    private void clearInputMap(JComponent jc){
-        subTabsShortcutMappings.forEach((k,v) -> jc.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
+    private void clearInputMap(JComponent jc) {
+        subTabsShortcutMappings.forEach((k, v) -> jc.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
                 KeyStroke.getKeyStroke(k), "none"));
     }
+
     private synchronized void set_isUpdateInProgress(boolean _isUpdateInProgress) {
         this._isUpdateInProgress = _isUpdateInProgress;
     }

--- a/src/main/java/com/irsdl/burp/sharpener/uiModifiers/toolsTabs/MainToolsTabStyleHandler.java
+++ b/src/main/java/com/irsdl/burp/sharpener/uiModifiers/toolsTabs/MainToolsTabStyleHandler.java
@@ -19,68 +19,66 @@ public class MainToolsTabStyleHandler {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new Thread(() -> {
-                    sharedParameters.printDebugMessage("setToolTabStyle for "+toolName);
-                    String themeName = sharedParameters.preferences.safeGetStringSetting("ToolsThemeName");
-                    String themeCustomPath = sharedParameters.preferences.safeGetStringSetting("ToolsThemeCustomPath");
-                    String iconSizeStr = sharedParameters.preferences.safeGetStringSetting("ToolsIconSize");
-                    int iconSize = Integer.parseInt(iconSizeStr, 32);
+                sharedParameters.printDebugMessage("setToolTabStyle for " + toolName);
+                String themeName = sharedParameters.preferences.safeGetStringSetting("ToolsThemeName");
+                String themeCustomPath = sharedParameters.preferences.safeGetStringSetting("ToolsThemeCustomPath");
+                String iconSizeStr = sharedParameters.preferences.safeGetStringSetting("ToolsIconSize");
+                int iconSize = Integer.parseInt(iconSizeStr, 32);
 
-                    JTabbedPane tabbedPane = sharedParameters.get_rootTabbedPane();
-                    for (Component component : tabbedPane.getComponents()) {
-                        int componentIndex = tabbedPane.indexOfComponent(component);
-                        if (componentIndex == -1) {
-                            continue;
-                        }
-
-                        String componentTitle = tabbedPane.getTitleAt(componentIndex);
-                        if (componentTitle.equalsIgnoreCase(toolName.toString())) {
-                            JComponent tabComponent = (JComponent) tabbedPane.getTabComponentAt(componentIndex);
-                            if (tabComponent.getComponent(0) instanceof JTextField) {
-
-                                JTextField jTextField = (JTextField) tabComponent.getComponent(0);
-                                jTextField.setFont(jTextField.getFont().deriveFont(Font.BOLD));
-                                jTextField.setOpaque(false);
-                                jTextField.setBorder(javax.swing.BorderFactory.createEmptyBorder());
-                                try {
-                                    Image myImg;
-                                    if (!themeName.equalsIgnoreCase("custom")) {
-                                        myImg = ImageHelper.scaleImageToWidth(ImageHelper.loadImageResource(sharedParameters.extensionClass, "/themes/" + themeName + "/" + toolName.toString() + ".png"), iconSize);
-                                    } else {
-                                        // custom path!
-                                        myImg = ImageHelper.scaleImageToWidth(ImageHelper.loadImageFile(themeCustomPath + "/" + toolName.toString() + ".png"), iconSize);
-                                        if (myImg == null) {
-                                            sharedParameters.printlnError("'" + themeCustomPath + "/" + toolName.toString() + ".png' could not be loaded or did not exist.");
-                                        }
-                                    }
-                                    JLabel jLabel;
-                                    if (myImg != null) {
-                                        ImageIcon imgIcon = new ImageIcon(myImg);
-                                        jLabel = new JLabel(imgIcon);
-                                    } else {
-                                        jLabel = new JLabel();
-                                    }
-                                    jLabel.setOpaque(false);
-                                    jLabel.setBorder(javax.swing.BorderFactory.createEmptyBorder());
-
-                                    //tabComponent.setLayout(new GridLayout(1, 2));
-                                    tabComponent.setLayout(new FlowLayout(FlowLayout.CENTER));
-                                    tabComponent.setSize(jTextField.getWidth() + jLabel.getWidth(), jLabel.getHeight());
-                                    tabComponent.remove(0);
-                                    tabComponent.add(jLabel);
-                                    tabComponent.add(jTextField);
-                                } catch (Exception e) {
-                                    e.printStackTrace(sharedParameters.stderr);
-                                }
-
-                                //tabComponent.revalidate();
-                                //tabComponent.repaint();
-
-                            }
-                            break;
-                        }
+                JTabbedPane tabbedPane = sharedParameters.get_rootTabbedPane();
+                for (Component component : tabbedPane.getComponents()) {
+                    int componentIndex = tabbedPane.indexOfComponent(component);
+                    if (componentIndex == -1) {
+                        continue;
                     }
-                }).start();
+
+                    String componentTitle = tabbedPane.getTitleAt(componentIndex);
+                    if (componentTitle.equalsIgnoreCase(toolName.toString())) {
+                        JComponent tabComponent = (JComponent) tabbedPane.getTabComponentAt(componentIndex);
+                        if (tabComponent.getComponent(0) instanceof JTextField) {
+
+                            JTextField jTextField = (JTextField) tabComponent.getComponent(0);
+                            jTextField.setFont(jTextField.getFont().deriveFont(Font.BOLD));
+                            jTextField.setOpaque(false);
+                            jTextField.setBorder(javax.swing.BorderFactory.createEmptyBorder());
+                            try {
+                                Image myImg;
+                                if (!themeName.equalsIgnoreCase("custom")) {
+                                    myImg = ImageHelper.scaleImageToWidth(ImageHelper.loadImageResource(sharedParameters.extensionClass, "/themes/" + themeName + "/" + toolName.toString() + ".png"), iconSize);
+                                } else {
+                                    // custom path!
+                                    myImg = ImageHelper.scaleImageToWidth(ImageHelper.loadImageFile(themeCustomPath + "/" + toolName.toString() + ".png"), iconSize);
+                                    if (myImg == null) {
+                                        sharedParameters.printlnError("'" + themeCustomPath + "/" + toolName.toString() + ".png' could not be loaded or did not exist.");
+                                    }
+                                }
+                                JLabel jLabel;
+                                if (myImg != null) {
+                                    ImageIcon imgIcon = new ImageIcon(myImg);
+                                    jLabel = new JLabel(imgIcon);
+                                } else {
+                                    jLabel = new JLabel();
+                                }
+                                jLabel.setOpaque(false);
+                                jLabel.setBorder(javax.swing.BorderFactory.createEmptyBorder());
+
+                                //tabComponent.setLayout(new GridLayout(1, 2));
+                                tabComponent.setLayout(new FlowLayout(FlowLayout.CENTER));
+                                tabComponent.setSize(jTextField.getWidth() + jLabel.getWidth(), jLabel.getHeight());
+                                tabComponent.remove(0);
+                                tabComponent.add(jLabel);
+                                tabComponent.add(jTextField);
+                            } catch (Exception e) {
+                                e.printStackTrace(sharedParameters.stderr);
+                            }
+
+                            tabComponent.revalidate();
+                            //tabComponent.repaint();
+
+                        }
+                        break;
+                    }
+                }
             }
         });
 
@@ -92,18 +90,16 @@ public class MainToolsTabStyleHandler {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new Thread(() -> {
-                    sharedParameters.printDebugMessage("setToolTabStylesFromSettings");
-                    if (sharedParameters.preferences.safeGetBooleanSetting("isToolTabPaneScrollable")) {
-                        sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
-                    }
+                sharedParameters.printDebugMessage("setToolTabStylesFromSettings");
+                if (sharedParameters.preferences.safeGetBooleanSetting("isToolTabPaneScrollable")) {
+                    sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
+                }
 
-                    for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
-                        if (sharedParameters.preferences.safeGetBooleanSetting("isUnique_" + tool)) {
-                            MainToolsTabStyleHandler.setToolTabStyle(sharedParameters, tool);
-                        }
+                for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
+                    if (sharedParameters.preferences.safeGetBooleanSetting("isUnique_" + tool)) {
+                        MainToolsTabStyleHandler.setToolTabStyle(sharedParameters, tool);
                     }
-                }).start();
+                }
             }
         });
     }
@@ -116,21 +112,19 @@ public class MainToolsTabStyleHandler {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new Thread(() -> {
-                    sharedParameters.printDebugMessage("setToolTabStylesFromSettings");
-                    if (sharedParameters.preferences.safeGetBooleanSetting("isToolTabPaneScrollable")) {
-                        sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
-                    }else{
-                        sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.WRAP_TAB_LAYOUT);
-                    }
+                sharedParameters.printDebugMessage("setToolTabStylesFromSettings");
+                if (sharedParameters.preferences.safeGetBooleanSetting("isToolTabPaneScrollable")) {
+                    sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
+                } else {
+                    sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.WRAP_TAB_LAYOUT);
+                }
 
-                    for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
-                        if (sharedParameters.preferences.safeGetBooleanSetting("isUnique_" + tool)) {
-                            MainToolsTabStyleHandler.unsetToolTabStyle(sharedParameters, tool);
-                            MainToolsTabStyleHandler.setToolTabStyle(sharedParameters, tool);
-                        }
+                for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
+                    if (sharedParameters.preferences.safeGetBooleanSetting("isUnique_" + tool)) {
+                        MainToolsTabStyleHandler.unsetToolTabStyle(sharedParameters, tool);
+                        MainToolsTabStyleHandler.setToolTabStyle(sharedParameters, tool);
                     }
-                }).start();
+                }
             }
         });
     }
@@ -139,16 +133,14 @@ public class MainToolsTabStyleHandler {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new Thread(() -> {
-                    sharedParameters.printDebugMessage("unsetAllToolTabStyles");
-                    if (sharedParameters.preferences.safeGetBooleanSetting("isToolTabPaneScrollable")) {
-                        sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.WRAP_TAB_LAYOUT);
-                    }
-                    for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
-                        //new Thread(() -> ToolsTabStyleHandler.unsetToolTabStyle(tool, tabbedPane)).start();
-                        MainToolsTabStyleHandler.unsetToolTabStyle(sharedParameters, tool);
-                    }
-                }).start();
+                sharedParameters.printDebugMessage("unsetAllToolTabStyles");
+                if (sharedParameters.preferences.safeGetBooleanSetting("isToolTabPaneScrollable")) {
+                    sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.WRAP_TAB_LAYOUT);
+                }
+                for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
+                    //new Thread(() -> ToolsTabStyleHandler.unsetToolTabStyle(tool, tabbedPane)).start();
+                    MainToolsTabStyleHandler.unsetToolTabStyle(sharedParameters, tool);
+                }
             }
         });
     }
@@ -157,34 +149,32 @@ public class MainToolsTabStyleHandler {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new Thread(() -> {
-                    JTabbedPane tabbedPane = sharedParameters.get_rootTabbedPane();
-                    for (Component component : tabbedPane.getComponents()) {
-                        int componentIndex = tabbedPane.indexOfComponent(component);
-                        if (componentIndex == -1) {
-                            continue;
-                        }
-
-                        String componentTitle = tabbedPane.getTitleAt(componentIndex);
-                        if (componentTitle == null)
-                            continue;
-
-                        if (componentTitle.equalsIgnoreCase(toolName.toString())) {
-                            JComponent tabComponent = (JComponent) tabbedPane.getTabComponentAt(componentIndex);
-                            if (tabComponent.getComponent(0) instanceof JLabel) {
-                                tabComponent.remove(0);
-                                JTextField jTextField = (JTextField) tabComponent.getComponent(0);
-                                jTextField.setFont(jTextField.getFont().deriveFont(Font.PLAIN));
-                                jTextField.setOpaque(false);
-                                jTextField.setBorder(javax.swing.BorderFactory.createEmptyBorder());
-                                tabComponent.setSize(jTextField.getWidth(), jTextField.getHeight());
-                                //tabComponent.revalidate();
-                                //tabComponent.repaint();
-                            }
-                            break;
-                        }
+                JTabbedPane tabbedPane = sharedParameters.get_rootTabbedPane();
+                for (Component component : tabbedPane.getComponents()) {
+                    int componentIndex = tabbedPane.indexOfComponent(component);
+                    if (componentIndex == -1) {
+                        continue;
                     }
-                }).start();
+
+                    String componentTitle = tabbedPane.getTitleAt(componentIndex);
+                    if (componentTitle == null)
+                        continue;
+
+                    if (componentTitle.equalsIgnoreCase(toolName.toString())) {
+                        JComponent tabComponent = (JComponent) tabbedPane.getTabComponentAt(componentIndex);
+                        if (tabComponent.getComponent(0) instanceof JLabel) {
+                            tabComponent.remove(0);
+                            JTextField jTextField = (JTextField) tabComponent.getComponent(0);
+                            jTextField.setFont(jTextField.getFont().deriveFont(Font.PLAIN));
+                            jTextField.setOpaque(false);
+                            jTextField.setBorder(javax.swing.BorderFactory.createEmptyBorder());
+                            tabComponent.setSize(jTextField.getWidth(), jTextField.getHeight());
+                            //tabComponent.revalidate();
+                            //tabComponent.repaint();
+                        }
+                        break;
+                    }
+                }
             }
         });
     }

--- a/src/main/java/com/irsdl/burp/sharpener/uiModifiers/toolsTabs/MainToolsTabWatcher.java
+++ b/src/main/java/com/irsdl/burp/sharpener/uiModifiers/toolsTabs/MainToolsTabWatcher.java
@@ -41,8 +41,13 @@ public class MainToolsTabWatcher implements ContainerListener {
                     new java.util.TimerTask() {
                         @Override
                         public void run() {
-                            MainToolsTabStyleHandler.resetToolTabStylesFromSettings(sharedParameters);
-                            setResetInProgress(false);
+                            SwingUtilities.invokeLater(new Runnable() {
+                                @Override
+                                public void run() {
+                                    MainToolsTabStyleHandler.resetToolTabStylesFromSettings(sharedParameters);
+                                    setResetInProgress(false);
+                                }
+                            });
                         }
                     },
                     2000 // 2 seconds-delay to ensure all has been settled!

--- a/src/main/java/com/irsdl/burp/sharpener/uiModifiers/topMenu/TopMenuBar.java
+++ b/src/main/java/com/irsdl/burp/sharpener/uiModifiers/topMenu/TopMenuBar.java
@@ -38,7 +38,7 @@ public class TopMenuBar extends javax.swing.JMenu {
     private JMenu topMenuForExtension;
     private final SharpenerSharedParameters sharedParameters;
     private final String[] themeNames = {"none", "halloween", "game", "hacker", "gradient", "mobster", "office"};
-    private final String[] iconSizes = {"48", "32", "24", "20", "16", "14", "12", "10" , "8", "6"};
+    private final String[] iconSizes = {"48", "32", "24", "20", "16", "14", "12", "10", "8", "6"};
     private final Boolean isPrefsRegistered = false;
 
     public TopMenuBar(SharpenerSharedParameters sharedParameters) {
@@ -52,478 +52,476 @@ public class TopMenuBar extends javax.swing.JMenu {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new Thread(() -> {
-                    removeAll();
+                removeAll();
 
-                    // Project menu
-                    JMenu projectMenu = new JMenu("Project Settings");
+                // Project menu
+                JMenu projectMenu = new JMenu("Project Settings");
 
-                    // Change title button
-                    JMenuItem changeTitle = new JMenuItem(new AbstractAction("Change Title") {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            String newTitle = UIHelper.showPlainInputMessage("Change Burp Suite Title String To:", "Change Burp Suite Title", sharedParameters.get_mainFrame().getTitle(), sharedParameters.get_mainFrame());
-                            if (newTitle != null && !newTitle.trim().isEmpty()) {
-                                if (!sharedParameters.get_mainFrame().getTitle().equals(newTitle)) {
-                                    BurpTitleAndIcon.setTitle(sharedParameters, newTitle);
-                                    sharedParameters.preferences.safeSetSetting("BurpTitle", newTitle);
-                                }
+                // Change title button
+                JMenuItem changeTitle = new JMenuItem(new AbstractAction("Change Title") {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        String newTitle = UIHelper.showPlainInputMessage("Change Burp Suite Title String To:", "Change Burp Suite Title", sharedParameters.get_mainFrame().getTitle(), sharedParameters.get_mainFrame());
+                        if (newTitle != null && !newTitle.trim().isEmpty()) {
+                            if (!sharedParameters.get_mainFrame().getTitle().equals(newTitle)) {
+                                BurpTitleAndIcon.setTitle(sharedParameters, newTitle);
+                                sharedParameters.preferences.safeSetSetting("BurpTitle", newTitle);
                             }
                         }
-                    });
-                    projectMenu.add(changeTitle);
-
-                    // Change title button
-                    String burpResourceIconName = sharedParameters.preferences.safeGetStringSetting("BurpResourceIconName");
-                    Resource[] resourceIcons = new Resource[]{};
-
-                    try {
-                        PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(sharedParameters.extensionClass.getClassLoader());
-                        resourceIcons = resolver.getResources("classpath:icons/*.*");
-
-                    } catch (IOException e) {
-                        sharedParameters.printDebugMessage("No icon was found in resources");
                     }
+                });
+                projectMenu.add(changeTitle);
 
-                    JMenu changeBurpIcon = new JMenu("Change Burp Suite Icon");
+                // Change title button
+                String burpResourceIconName = sharedParameters.preferences.safeGetStringSetting("BurpResourceIconName");
+                Resource[] resourceIcons = new Resource[]{};
 
-                    ButtonGroup burpIconGroup = new ButtonGroup();
-                    for(Resource resourceIcon: resourceIcons){
-                        String resourcePath = "/icons/"+resourceIcon.getFilename();
-                        JRadioButtonMenuItem burpIconImage = new JRadioButtonMenuItem(resourceIcon.getFilename().replaceAll("\\..*$",""));
-                        burpIconImage.setIcon(new ImageIcon(ImageHelper.scaleImageToWidth(ImageHelper.loadImageResource(sharedParameters.extensionClass, resourcePath), 16)));
-                        if (resourceIcon.getFilename().equalsIgnoreCase(burpResourceIconName)) {
-                            burpIconImage.setSelected(true);
-                        }
-                        burpIconImage.addActionListener((e) -> {
-                            BurpTitleAndIcon.setIcon(sharedParameters, resourcePath, 48, true);
-                            sharedParameters.preferences.safeSetSetting("BurpResourceIconName", resourcePath);
-                            sharedParameters.preferences.safeSetSetting("BurpIconCustomPath", "");
-                        });
-                        burpIconGroup.add(burpIconImage);
-                        changeBurpIcon.add(burpIconImage);
-                    }
+                try {
+                    PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(sharedParameters.extensionClass.getClassLoader());
+                    resourceIcons = resolver.getResources("classpath:icons/*.*");
 
-                    JRadioButtonMenuItem burpIconImage = new JRadioButtonMenuItem("Custom");
-                    if(!((String) sharedParameters.preferences.safeGetStringSetting("BurpIconCustomPath")).isBlank()){
+                } catch (IOException e) {
+                    sharedParameters.printDebugMessage("No icon was found in resources");
+                }
+
+                JMenu changeBurpIcon = new JMenu("Change Burp Suite Icon");
+
+                ButtonGroup burpIconGroup = new ButtonGroup();
+                for (Resource resourceIcon : resourceIcons) {
+                    String resourcePath = "/icons/" + resourceIcon.getFilename();
+                    JRadioButtonMenuItem burpIconImage = new JRadioButtonMenuItem(resourceIcon.getFilename().replaceAll("\\..*$", ""));
+                    burpIconImage.setIcon(new ImageIcon(ImageHelper.scaleImageToWidth(ImageHelper.loadImageResource(sharedParameters.extensionClass, resourcePath), 16)));
+                    if (resourceIcon.getFilename().equalsIgnoreCase(burpResourceIconName)) {
                         burpIconImage.setSelected(true);
                     }
-
-                    burpIconImage.addActionListener(new AbstractAction() {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            String lastIconPath = sharedParameters.preferences.safeGetStringSetting("LastBurpIconCustomPath");
-                            FileFilter imageFilter = new FileNameExtensionFilter("Image files", ImageIO.getReaderFileSuffixes());
-                            String newIconPath = UIHelper.showFileDialog(lastIconPath, imageFilter, sharedParameters.get_mainFrame());
-                            if (newIconPath != null && !newIconPath.trim().isEmpty()) {
-                                BurpTitleAndIcon.setIcon(sharedParameters, newIconPath, 48, false);
-                                sharedParameters.preferences.safeSetSetting("BurpResourceIconName", "");
-                                sharedParameters.preferences.safeSetSetting("BurpIconCustomPath", newIconPath);
-                                sharedParameters.preferences.safeSetSetting("LastBurpIconCustomPath", newIconPath);
-                            }
-                        }
+                    burpIconImage.addActionListener((e) -> {
+                        BurpTitleAndIcon.setIcon(sharedParameters, resourcePath, 48, true);
+                        sharedParameters.preferences.safeSetSetting("BurpResourceIconName", resourcePath);
+                        sharedParameters.preferences.safeSetSetting("BurpIconCustomPath", "");
                     });
                     burpIconGroup.add(burpIconImage);
                     changeBurpIcon.add(burpIconImage);
+                }
 
-                    projectMenu.add(changeBurpIcon);
+                JRadioButtonMenuItem burpIconImage = new JRadioButtonMenuItem("Custom");
+                if (!((String) sharedParameters.preferences.safeGetStringSetting("BurpIconCustomPath")).isBlank()) {
+                    burpIconImage.setSelected(true);
+                }
 
-
-                    // Reset title button
-                    JMenuItem resetTitle = new JMenuItem(new AbstractAction("Reset Burp Suite Title") {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            int response = UIHelper.askConfirmMessage("Sharpener Extension: Reset Title", "Are you sure?", new String[]{"Yes", "No"}, sharedParameters.get_mainFrame());
-                            if (response == 0) {
-                                BurpTitleAndIcon.resetTitle(sharedParameters);
-                                sharedParameters.preferences.safeSetSetting("BurpTitle", "");
-                            }
+                burpIconImage.addActionListener(new AbstractAction() {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        String lastIconPath = sharedParameters.preferences.safeGetStringSetting("LastBurpIconCustomPath");
+                        FileFilter imageFilter = new FileNameExtensionFilter("Image files", ImageIO.getReaderFileSuffixes());
+                        String newIconPath = UIHelper.showFileDialog(lastIconPath, imageFilter, sharedParameters.get_mainFrame());
+                        if (newIconPath != null && !newIconPath.trim().isEmpty()) {
+                            BurpTitleAndIcon.setIcon(sharedParameters, newIconPath, 48, false);
+                            sharedParameters.preferences.safeSetSetting("BurpResourceIconName", "");
+                            sharedParameters.preferences.safeSetSetting("BurpIconCustomPath", newIconPath);
+                            sharedParameters.preferences.safeSetSetting("LastBurpIconCustomPath", newIconPath);
                         }
-                    });
-                    projectMenu.add(resetTitle);
-
-                    // Reset icon button
-                    JMenuItem resetIcon = new JMenuItem(new AbstractAction("Reset Burp Suite Icon") {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            int response = UIHelper.askConfirmMessage("Sharpener Extension: Reset Icon", "Are you sure?", new String[]{"Yes", "No"}, sharedParameters.get_mainFrame());
-                            if (response == 0) {
-                                BurpTitleAndIcon.resetIcon(sharedParameters);
-                                sharedParameters.preferences.safeSetSetting("BurpIconCustomPath", "");
-                            }
-                        }
-                    });
-                    projectMenu.add(resetIcon);
-                    add(projectMenu);
-
-                    // Global menu
-                    JMenu globalMenu = new JMenu("Global Settings");
-
-                    // Style menu
-                    JMenu toolsUniqueStyleMenu = new JMenu("Burp-Tools' Unique Style");
-                    JMenuItem enableAll = new JMenuItem(new AbstractAction("Enable All") {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
-                                sharedParameters.preferences.safeSetSetting("isUnique_" + tool, true);
-                                MainToolsTabStyleHandler.setToolTabStyle(sharedParameters, tool);
-                            }
-                            updateTopMenuBar();
-                            //reAddTopMenuBar();
-                        }
-                    });
-                    toolsUniqueStyleMenu.add(enableAll);
-                    JMenuItem disableAll = new JMenuItem(new AbstractAction("Disable All") {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
-                                sharedParameters.preferences.safeSetSetting("isUnique_" + tool, false);
-                                MainToolsTabStyleHandler.unsetToolTabStyle(sharedParameters, tool);
-                            }
-                            updateTopMenuBar();
-                            //reAddTopMenuBar();
-                        }
-                    });
-                    toolsUniqueStyleMenu.add(disableAll);
-
-                    toolsUniqueStyleMenu.addSeparator();
-
-                    String themeName = sharedParameters.preferences.safeGetStringSetting("ToolsThemeName");
-                    JMenu toolsUniqueStyleThemeMenu = new JMenu("Icons' Theme");
-                    ButtonGroup themeGroup = new ButtonGroup();
-                    for (String definedThemeName : themeNames) {
-                        JRadioButtonMenuItem toolStyleTheme = new JRadioButtonMenuItem(definedThemeName);
-                        if (themeName.equalsIgnoreCase(definedThemeName) || (themeName.isEmpty() && definedThemeName.equalsIgnoreCase("none"))) {
-                            toolStyleTheme.setSelected(true);
-                        }
-                        toolStyleTheme.addActionListener((e) -> {
-                            String chosenOne = definedThemeName;
-                            if (chosenOne.equalsIgnoreCase("none"))
-                                chosenOne = "";
-                            sharedParameters.preferences.safeSetSetting("ToolsThemeName", chosenOne);
-                            MainToolsTabStyleHandler.resetToolTabStylesFromSettings(sharedParameters);
-                        });
-                        themeGroup.add(toolStyleTheme);
-                        toolsUniqueStyleThemeMenu.add(toolStyleTheme);
                     }
+                });
+                burpIconGroup.add(burpIconImage);
+                changeBurpIcon.add(burpIconImage);
 
-                    JRadioButtonMenuItem toolStyleThemeCustom = new JRadioButtonMenuItem("custom directory");
-                    if (themeName.equalsIgnoreCase("custom")) {
-                        toolStyleThemeCustom.setSelected(true);
-                    }
-                    toolStyleThemeCustom.addActionListener((e) -> {
-                        String themeCustomPath = sharedParameters.preferences.safeGetStringSetting("ToolsThemeCustomPath");
-                        String customPath = UIHelper.showDirectoryDialog(themeCustomPath, sharedParameters.get_mainFrame());
-                        if (!customPath.isEmpty()) {
-                            sharedParameters.preferences.safeSetSetting("ToolsThemeName", "custom");
-                            sharedParameters.preferences.safeSetSetting("ToolsThemeCustomPath", customPath);
-                        } else {
-                            updateTopMenuBar();
-                            //reAddTopMenuBar();
+                projectMenu.add(changeBurpIcon);
+
+
+                // Reset title button
+                JMenuItem resetTitle = new JMenuItem(new AbstractAction("Reset Burp Suite Title") {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        int response = UIHelper.askConfirmMessage("Sharpener Extension: Reset Title", "Are you sure?", new String[]{"Yes", "No"}, sharedParameters.get_mainFrame());
+                        if (response == 0) {
+                            BurpTitleAndIcon.resetTitle(sharedParameters);
+                            sharedParameters.preferences.safeSetSetting("BurpTitle", "");
                         }
+                    }
+                });
+                projectMenu.add(resetTitle);
+
+                // Reset icon button
+                JMenuItem resetIcon = new JMenuItem(new AbstractAction("Reset Burp Suite Icon") {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        int response = UIHelper.askConfirmMessage("Sharpener Extension: Reset Icon", "Are you sure?", new String[]{"Yes", "No"}, sharedParameters.get_mainFrame());
+                        if (response == 0) {
+                            BurpTitleAndIcon.resetIcon(sharedParameters);
+                            sharedParameters.preferences.safeSetSetting("BurpIconCustomPath", "");
+                        }
+                    }
+                });
+                projectMenu.add(resetIcon);
+                add(projectMenu);
+
+                // Global menu
+                JMenu globalMenu = new JMenu("Global Settings");
+
+                // Style menu
+                JMenu toolsUniqueStyleMenu = new JMenu("Burp-Tools' Unique Style");
+                JMenuItem enableAll = new JMenuItem(new AbstractAction("Enable All") {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
+                            sharedParameters.preferences.safeSetSetting("isUnique_" + tool, true);
+                            MainToolsTabStyleHandler.setToolTabStyle(sharedParameters, tool);
+                        }
+                        updateTopMenuBar();
+                        //reAddTopMenuBar();
+                    }
+                });
+                toolsUniqueStyleMenu.add(enableAll);
+                JMenuItem disableAll = new JMenuItem(new AbstractAction("Disable All") {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
+                            sharedParameters.preferences.safeSetSetting("isUnique_" + tool, false);
+                            MainToolsTabStyleHandler.unsetToolTabStyle(sharedParameters, tool);
+                        }
+                        updateTopMenuBar();
+                        //reAddTopMenuBar();
+                    }
+                });
+                toolsUniqueStyleMenu.add(disableAll);
+
+                toolsUniqueStyleMenu.addSeparator();
+
+                String themeName = sharedParameters.preferences.safeGetStringSetting("ToolsThemeName");
+                JMenu toolsUniqueStyleThemeMenu = new JMenu("Icons' Theme");
+                ButtonGroup themeGroup = new ButtonGroup();
+                for (String definedThemeName : themeNames) {
+                    JRadioButtonMenuItem toolStyleTheme = new JRadioButtonMenuItem(definedThemeName);
+                    if (themeName.equalsIgnoreCase(definedThemeName) || (themeName.isEmpty() && definedThemeName.equalsIgnoreCase("none"))) {
+                        toolStyleTheme.setSelected(true);
+                    }
+                    toolStyleTheme.addActionListener((e) -> {
+                        String chosenOne = definedThemeName;
+                        if (chosenOne.equalsIgnoreCase("none"))
+                            chosenOne = "";
+                        sharedParameters.preferences.safeSetSetting("ToolsThemeName", chosenOne);
                         MainToolsTabStyleHandler.resetToolTabStylesFromSettings(sharedParameters);
                     });
-                    themeGroup.add(toolStyleThemeCustom);
-                    toolsUniqueStyleThemeMenu.add(toolStyleThemeCustom);
-                    toolsUniqueStyleMenu.add(toolsUniqueStyleThemeMenu);
+                    themeGroup.add(toolStyleTheme);
+                    toolsUniqueStyleThemeMenu.add(toolStyleTheme);
+                }
 
-                    String iconSize = sharedParameters.preferences.safeGetStringSetting("ToolsIconSize");
-                    JMenu toolsUniqueStyleIconSizeMenu = new JMenu("Icons' Size");
-                    ButtonGroup iconSizeGroup = new ButtonGroup();
-                    for (String definedIconSize: iconSizes) {
-                        JRadioButtonMenuItem toolIconSize = new JRadioButtonMenuItem(definedIconSize);
-                        if (iconSize.equals(definedIconSize)) {
-                            toolIconSize.setSelected(true);
-                        }
-                        toolIconSize.addActionListener((e) -> {
-                            String chosenOne = definedIconSize;
-                            sharedParameters.preferences.safeSetSetting("ToolsIconSize", chosenOne);
-                            MainToolsTabStyleHandler.resetToolTabStylesFromSettings(sharedParameters);
-                        });
-                        iconSizeGroup.add(toolIconSize);
-                        toolsUniqueStyleIconSizeMenu.add(toolIconSize);
+                JRadioButtonMenuItem toolStyleThemeCustom = new JRadioButtonMenuItem("custom directory");
+                if (themeName.equalsIgnoreCase("custom")) {
+                    toolStyleThemeCustom.setSelected(true);
+                }
+                toolStyleThemeCustom.addActionListener((e) -> {
+                    String themeCustomPath = sharedParameters.preferences.safeGetStringSetting("ToolsThemeCustomPath");
+                    String customPath = UIHelper.showDirectoryDialog(themeCustomPath, sharedParameters.get_mainFrame());
+                    if (!customPath.isEmpty()) {
+                        sharedParameters.preferences.safeSetSetting("ToolsThemeName", "custom");
+                        sharedParameters.preferences.safeSetSetting("ToolsThemeCustomPath", customPath);
+                    } else {
+                        updateTopMenuBar();
+                        //reAddTopMenuBar();
                     }
-                    toolsUniqueStyleMenu.add(toolsUniqueStyleIconSizeMenu);
+                    MainToolsTabStyleHandler.resetToolTabStylesFromSettings(sharedParameters);
+                });
+                themeGroup.add(toolStyleThemeCustom);
+                toolsUniqueStyleThemeMenu.add(toolStyleThemeCustom);
+                toolsUniqueStyleMenu.add(toolsUniqueStyleThemeMenu);
 
-                    toolsUniqueStyleMenu.addSeparator();
-
-                    for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
-                        if (tool.toString().equalsIgnoreCase("none"))
-                            continue;
-                        JCheckBoxMenuItem toolStyleOption = new JCheckBoxMenuItem(tool.toString());
-                        if (sharedParameters.preferences.safeGetBooleanSetting("isUnique_" + tool)) {
-                            toolStyleOption.setSelected(true);
-                        }
-                        toolStyleOption.addActionListener((e) -> {
-                            Boolean currentSetting = sharedParameters.preferences.safeGetBooleanSetting("isUnique_" + tool);
-                            if (currentSetting) {
-                                sharedParameters.preferences.safeSetSetting("isUnique_" + tool, false);
-                                MainToolsTabStyleHandler.unsetToolTabStyle(sharedParameters, tool);
-                            } else {
-                                sharedParameters.preferences.safeSetSetting("isUnique_" + tool, true);
-                                MainToolsTabStyleHandler.setToolTabStyle(sharedParameters, tool);
-                            }
-                        });
-                        toolsUniqueStyleMenu.add(toolStyleOption);
+                String iconSize = sharedParameters.preferences.safeGetStringSetting("ToolsIconSize");
+                JMenu toolsUniqueStyleIconSizeMenu = new JMenu("Icons' Size");
+                ButtonGroup iconSizeGroup = new ButtonGroup();
+                for (String definedIconSize : iconSizes) {
+                    JRadioButtonMenuItem toolIconSize = new JRadioButtonMenuItem(definedIconSize);
+                    if (iconSize.equals(definedIconSize)) {
+                        toolIconSize.setSelected(true);
                     }
-                    globalMenu.add(toolsUniqueStyleMenu);
+                    toolIconSize.addActionListener((e) -> {
+                        String chosenOne = definedIconSize;
+                        sharedParameters.preferences.safeSetSetting("ToolsIconSize", chosenOne);
+                        MainToolsTabStyleHandler.resetToolTabStylesFromSettings(sharedParameters);
+                    });
+                    iconSizeGroup.add(toolIconSize);
+                    toolsUniqueStyleIconSizeMenu.add(toolIconSize);
+                }
+                toolsUniqueStyleMenu.add(toolsUniqueStyleIconSizeMenu);
 
-                    JCheckBoxMenuItem topMenuScrollableLayout = new JCheckBoxMenuItem("Scrollable Tool Pane");
+                toolsUniqueStyleMenu.addSeparator();
 
-                    if (sharedParameters.preferences.safeGetBooleanSetting("isToolTabPaneScrollable")) {
-                        topMenuScrollableLayout.setSelected(true);
+                for (BurpUITools.MainTabs tool : BurpUITools.MainTabs.values()) {
+                    if (tool.toString().equalsIgnoreCase("none"))
+                        continue;
+                    JCheckBoxMenuItem toolStyleOption = new JCheckBoxMenuItem(tool.toString());
+                    if (sharedParameters.preferences.safeGetBooleanSetting("isUnique_" + tool)) {
+                        toolStyleOption.setSelected(true);
                     }
-
-                    topMenuScrollableLayout.addActionListener((e) -> {
-                        boolean isToolTabPaneScrollable = sharedParameters.preferences.safeGetBooleanSetting("isToolTabPaneScrollable");
-                        if (isToolTabPaneScrollable) {
-                            SwingUtilities.invokeLater(new Runnable() {
-                                @Override
-                                public void run() {
-                                    new Thread(() -> {
-                                        sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.WRAP_TAB_LAYOUT);
-                                    }).start();
-                                }
-                            });
-                            sharedParameters.preferences.safeSetSetting("isToolTabPaneScrollable", false);
+                    toolStyleOption.addActionListener((e) -> {
+                        Boolean currentSetting = sharedParameters.preferences.safeGetBooleanSetting("isUnique_" + tool);
+                        if (currentSetting) {
+                            sharedParameters.preferences.safeSetSetting("isUnique_" + tool, false);
+                            MainToolsTabStyleHandler.unsetToolTabStyle(sharedParameters, tool);
                         } else {
-                            SwingUtilities.invokeLater(new Runnable() {
-                                @Override
-                                public void run() {
-                                    new Thread(() -> {
-                                        sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
-                                    }).start();
-                                }
-                            });
-                            sharedParameters.preferences.safeSetSetting("isToolTabPaneScrollable", true);
+                            sharedParameters.preferences.safeSetSetting("isUnique_" + tool, true);
+                            MainToolsTabStyleHandler.setToolTabStyle(sharedParameters, tool);
                         }
                     });
+                    toolsUniqueStyleMenu.add(toolStyleOption);
+                }
+                globalMenu.add(toolsUniqueStyleMenu);
 
-                    globalMenu.add(topMenuScrollableLayout);
+                JCheckBoxMenuItem topMenuScrollableLayout = new JCheckBoxMenuItem("Scrollable Tool Pane");
 
-                    JMenu supportedCapabilitiesMenu = new JMenu("Supported Capabilities");
+                if (sharedParameters.preferences.safeGetBooleanSetting("isToolTabPaneScrollable")) {
+                    topMenuScrollableLayout.setSelected(true);
+                }
 
-                    JCheckBoxMenuItem pwnFoxSupportCapability = new JCheckBoxMenuItem("PwnFox Highlighter");
-                    pwnFoxSupportCapability.setToolTipText("Useful when PwnFox extension is enabled in Firefox");
+                topMenuScrollableLayout.addActionListener((e) -> {
+                    boolean isToolTabPaneScrollable = sharedParameters.preferences.safeGetBooleanSetting("isToolTabPaneScrollable");
+                    if (isToolTabPaneScrollable) {
+                        SwingUtilities.invokeLater(new Runnable() {
+                            @Override
+                            public void run() {
+                                sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.WRAP_TAB_LAYOUT);
+                            }
+                        });
+                        sharedParameters.preferences.safeSetSetting("isToolTabPaneScrollable", false);
+                    } else {
+                        SwingUtilities.invokeLater(new Runnable() {
+                            @Override
+                            public void run() {
+                                sharedParameters.get_rootTabbedPane().setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
+                            }
+                        });
+                        sharedParameters.preferences.safeSetSetting("isToolTabPaneScrollable", true);
+                    }
+                });
+
+                globalMenu.add(topMenuScrollableLayout);
+
+                JMenu supportedCapabilitiesMenu = new JMenu("Supported Capabilities");
+
+                JCheckBoxMenuItem pwnFoxSupportCapability = new JCheckBoxMenuItem("PwnFox Highlighter");
+                pwnFoxSupportCapability.setToolTipText("Useful when PwnFox extension is enabled in Firefox");
+                if (sharedParameters.preferences.safeGetBooleanSetting("pwnFoxSupportCapability")) {
+                    pwnFoxSupportCapability.setSelected(true);
+                }
+                pwnFoxSupportCapability.addActionListener((e) -> {
                     if (sharedParameters.preferences.safeGetBooleanSetting("pwnFoxSupportCapability")) {
-                        pwnFoxSupportCapability.setSelected(true);
+                        sharedParameters.preferences.safeSetSetting("pwnFoxSupportCapability", false);
+                    } else {
+                        sharedParameters.preferences.safeSetSetting("pwnFoxSupportCapability", true);
                     }
-                    pwnFoxSupportCapability.addActionListener((e) -> {
-                        if (sharedParameters.preferences.safeGetBooleanSetting("pwnFoxSupportCapability")) {
-                            sharedParameters.preferences.safeSetSetting("pwnFoxSupportCapability", false);
-                        } else {
-                            sharedParameters.preferences.safeSetSetting("pwnFoxSupportCapability", true);
-                        }
-                    });
-                    supportedCapabilitiesMenu.add(pwnFoxSupportCapability);
+                });
+                supportedCapabilitiesMenu.add(pwnFoxSupportCapability);
 
-                    globalMenu.add(supportedCapabilitiesMenu);
+                globalMenu.add(supportedCapabilitiesMenu);
 
-                    // Debug options
-                    JMenu debugMenu = new JMenu("Debug Settings");
-                    ButtonGroup debugButtonGroup = new ButtonGroup();
+                // Debug options
+                JMenu debugMenu = new JMenu("Debug Settings");
+                ButtonGroup debugButtonGroup = new ButtonGroup();
 
-                    JRadioButtonMenuItem debugOptionDisabled = new JRadioButtonMenuItem(new AbstractAction("Disabled") {
-                        @Override
-                        public void actionPerformed(ActionEvent e) {
-                            sharedParameters.preferences.safeSetSetting("debugLevel", 0);
-                            sharedParameters.debugLevel = 0;
-                        }
-                    });
-                    if(sharedParameters.debugLevel == 0)
-                        debugOptionDisabled.setSelected(true);
+                JRadioButtonMenuItem debugOptionDisabled = new JRadioButtonMenuItem(new AbstractAction("Disabled") {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        sharedParameters.preferences.safeSetSetting("debugLevel", 0);
+                        sharedParameters.debugLevel = 0;
+                    }
+                });
+                if (sharedParameters.debugLevel == 0)
+                    debugOptionDisabled.setSelected(true);
 
-                    debugButtonGroup.add(debugOptionDisabled);
-                    debugMenu.add(debugOptionDisabled);
+                debugButtonGroup.add(debugOptionDisabled);
+                debugMenu.add(debugOptionDisabled);
 
-                    JRadioButtonMenuItem debugOptionVerbose = new JRadioButtonMenuItem(new AbstractAction("Verbose") {
-                        @Override
-                        public void actionPerformed(ActionEvent e) {
-                            sharedParameters.preferences.safeSetSetting("debugLevel", 1);
-                            sharedParameters.debugLevel = 1;
-                        }
-                    });
-                    if(sharedParameters.debugLevel == 1)
-                        debugOptionVerbose.setSelected(true);
-                    debugButtonGroup.add(debugOptionVerbose);
-                    debugMenu.add(debugOptionVerbose);
+                JRadioButtonMenuItem debugOptionVerbose = new JRadioButtonMenuItem(new AbstractAction("Verbose") {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        sharedParameters.preferences.safeSetSetting("debugLevel", 1);
+                        sharedParameters.debugLevel = 1;
+                    }
+                });
+                if (sharedParameters.debugLevel == 1)
+                    debugOptionVerbose.setSelected(true);
+                debugButtonGroup.add(debugOptionVerbose);
+                debugMenu.add(debugOptionVerbose);
 
-                    JRadioButtonMenuItem debugOptionVeryVerbose = new JRadioButtonMenuItem(new AbstractAction("Very Verbose") {
-                        @Override
-                        public void actionPerformed(ActionEvent e) {
-                            sharedParameters.preferences.safeSetSetting("debugLevel", 2);
-                            sharedParameters.debugLevel = 2;
-                        }
-                    });
-                    if(sharedParameters.debugLevel > 1)
-                        debugOptionVeryVerbose.setSelected(true);
-                    debugButtonGroup.add(debugOptionVeryVerbose);
-                    debugMenu.add(debugOptionVeryVerbose);
-                    globalMenu.add(debugMenu);
+                JRadioButtonMenuItem debugOptionVeryVerbose = new JRadioButtonMenuItem(new AbstractAction("Very Verbose") {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        sharedParameters.preferences.safeSetSetting("debugLevel", 2);
+                        sharedParameters.debugLevel = 2;
+                    }
+                });
+                if (sharedParameters.debugLevel > 1)
+                    debugOptionVeryVerbose.setSelected(true);
+                debugButtonGroup.add(debugOptionVeryVerbose);
+                debugMenu.add(debugOptionVeryVerbose);
+                globalMenu.add(debugMenu);
 
-                    add(globalMenu);
-                    addSeparator();
+                add(globalMenu);
+                addSeparator();
 
-                    JMenuItem unloadExtension = new JMenuItem(new AbstractAction("Unload Extension") {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            try {
-                                int response = UIHelper.askConfirmMessage("Sharpener Extension Unload", "Are you sure you want to unload the extension?", new String[]{"Yes", "No"}, sharedParameters.get_mainFrame());
-                                if (response == 0) {
-                                    sharedParameters.callbacks.unloadExtension();
-                                }
-                            }catch(NoClassDefFoundError | Exception e){
-                                // It seems the extension is dead and we are left with a top menu bar
-                            }
-
-                            try{
-                                new Timer().schedule(
-                                        new TimerTask() {
-                                            @Override
-                                            public void run() {
-                                                // This is useful when the extension has been unloaded but the menu is still there because of an error
-                                                // We should force removing the top menu bar from Burp using all native libraries
-                                                JRootPane rootPane = topMenuForExtension.getRootPane();
-                                                if(rootPane!=null){
-                                                    JTabbedPane rootTabbedPane = (JTabbedPane) rootPane.getContentPane().getComponent(0);
-                                                    JFrame mainFrame = (JFrame) rootTabbedPane.getRootPane().getParent();
-                                                    JMenuBar mainMenuBar = mainFrame.getJMenuBar();
-                                                    mainMenuBar.remove(topMenuForExtension);
-                                                    mainFrame.validate();
-                                                    mainFrame.repaint();
-                                                }
-                                            }
-                                        },
-                                        5000 // 5 seconds-delay to ensure all has been settled!
-                                );
-                            }catch (Exception e){
-
-                            }
-                        }
-                    });
-                    add(unloadExtension);
-
-                    JMenuItem reloadAllSettings = new JMenuItem(new AbstractAction("Reload All Settings") {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            new Thread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    MainToolsTabStyleHandler.resetToolTabStylesFromSettings(sharedParameters);
-                                    //sharedParameters.allSettings.subTabSettings.unsetSubTabsStyle();
-                                    SharpenerBurpExtender sharpenerBurpExtender = (SharpenerBurpExtender) sharedParameters.burpExtender;
-                                    sharpenerBurpExtender.load(true);
-
-                                }
-                            }).start();
-                        }
-                    });
-                    add(reloadAllSettings);
-
-                    JMenuItem resetAllSettings = new JMenuItem(new AbstractAction("Remove All Settings & Unload") {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            int response = UIHelper.askConfirmMessage("Sharpener Extension: Reset All Settings & Unload", "Are you sure you want to remove all the settings and unload the extension?", new String[]{"Yes", "No"}, sharedParameters.get_mainFrame());
+                JMenuItem unloadExtension = new JMenuItem(new AbstractAction("Unload Extension") {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        try {
+                            int response = UIHelper.askConfirmMessage("Sharpener Extension Unload", "Are you sure you want to unload the extension?", new String[]{"Yes", "No"}, sharedParameters.get_mainFrame());
                             if (response == 0) {
-
-                                // A bug in resetting settings in BurpExtenderUtilities should be fixed so we will give it another chance instead of using a workaround
-                                // sharedParameters.resetAllSettings();
-                                sharedParameters.preferences.resetAllSettings();
                                 sharedParameters.callbacks.unloadExtension();
                             }
+                        } catch (NoClassDefFoundError | Exception e) {
+                            // It seems the extension is dead and we are left with a top menu bar
                         }
-                    });
 
-                    add(resetAllSettings);
-                    addSeparator();
+                        try {
+                            new Timer().schedule(
+                                    new TimerTask() {
+                                        @Override
+                                        public void run() {
+                                            SwingUtilities.invokeLater(new Runnable() {
+                                                @Override
+                                                public void run() {
+                                                    // This is useful when the extension has been unloaded but the menu is still there because of an error
+                                                    // We should force removing the top menu bar from Burp using all native libraries
+                                                    JRootPane rootPane = topMenuForExtension.getRootPane();
+                                                    if (rootPane != null) {
+                                                        JTabbedPane rootTabbedPane = (JTabbedPane) rootPane.getContentPane().getComponent(0);
+                                                        JFrame mainFrame = (JFrame) rootTabbedPane.getRootPane().getParent();
+                                                        JMenuBar mainMenuBar = mainFrame.getJMenuBar();
+                                                        mainMenuBar.remove(topMenuForExtension);
+                                                        mainFrame.validate();
+                                                        mainFrame.repaint();
+                                                    }
+                                                }
+                                            });
+                                        }
+                                    },
+                                    5000 // 5 seconds-delay to ensure all has been settled!
+                            );
+                        } catch (Exception e) {
 
-                    JCheckBoxMenuItem checkForUpdateOption = new JCheckBoxMenuItem("Check for Update on Start");
-                    checkForUpdateOption.setToolTipText("Check is done by accessing its GitHub repository");
-                    if (sharedParameters.preferences.safeGetBooleanSetting("checkForUpdate")) {
-                        checkForUpdateOption.setSelected(true);
+                        }
                     }
+                });
+                add(unloadExtension);
 
-                    checkForUpdateOption.addActionListener((e) -> {
-                        if (sharedParameters.preferences.safeGetBooleanSetting("checkForUpdate")) {
-                            sharedParameters.preferences.safeSetSetting("checkForUpdate", false);
-                        } else {
-                            sharedParameters.preferences.safeSetSetting("checkForUpdate", true);
-                            SharpenerBurpExtender sharpenerBurpExtender = (SharpenerBurpExtender) sharedParameters.burpExtender;
-                            sharpenerBurpExtender.checkForUpdate();
-                        }
-                    });
-                    add(checkForUpdateOption);
+                JMenuItem reloadAllSettings = new JMenuItem(new AbstractAction("Reload All Settings") {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        new Thread(new Runnable() {
+                            @Override
+                            public void run() {
+                                MainToolsTabStyleHandler.resetToolTabStylesFromSettings(sharedParameters);
+                                //sharedParameters.allSettings.subTabSettings.unsetSubTabsStyle();
+                                SharpenerBurpExtender sharpenerBurpExtender = (SharpenerBurpExtender) sharedParameters.burpExtender;
+                                sharpenerBurpExtender.load(true);
 
-                    JMenuItem showProjectPage = new JMenuItem(new AbstractAction("Project Page") {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            new Thread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    try {
-                                        Desktop.getDesktop().browse(new URI(sharedParameters.extensionURL));
-                                    } catch (Exception e) {
-                                    }
-                                }
-                            }).start();
-                        }
-                    });
-                    showProjectPage.setToolTipText("Will be opened in the default browser");
-                    add(showProjectPage);
-
-                    JMenuItem reportAnIssue = new JMenuItem(new AbstractAction("Report Bug/Feature") {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            new Thread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    try {
-                                        Desktop.getDesktop().browse(new URI(sharedParameters.extensionIssueTracker));
-                                    } catch (Exception e) {
-                                    }
-                                }
-                            }).start();
-                        }
-                    });
-                    reportAnIssue.setToolTipText("Will be opened in the default browser");
-                    add(reportAnIssue);
-
-                    addSeparator();
-
-                    Image mdsecLogoImg;
-                    if(sharedParameters.isDarkMode){
-                        mdsecLogoImg = ImageHelper.scaleImageToWidth(ImageHelper.loadImageResource(sharedParameters.extensionClass, "/MDSec-logo-grey.png"), 100);
-                    }else{
-                        mdsecLogoImg = ImageHelper.scaleImageToWidth(ImageHelper.loadImageResource(sharedParameters.extensionClass, "/MDSec-logo-blue.png"), 100);
-                    }
-                    ImageIcon mdsecLogoIcon = new ImageIcon(mdsecLogoImg);
-                    JMenuItem mdsecLogoMenu = new JMenuItem(mdsecLogoIcon);
-                    mdsecLogoMenu.setPreferredSize(new Dimension(100,50));
-
-                    mdsecLogoMenu.setToolTipText("About this extension");
-                    mdsecLogoMenu.addActionListener(new AbstractAction() {
-                        @Override
-                        public void actionPerformed(ActionEvent actionEvent) {
-                            String aboutMessage = "Burp Suite " + sharedParameters.extensionName + " - version " + sharedParameters.version +
-                                    "\nReleased as open source by MDSec - https://www.mdsec.co.uk/\n" +
-                                    "Developed by Soroush Dalili (@irsdl)\n" +
-                                    "Project link: " + sharedParameters.extensionURL +
-                                    "\nReleased under AGPL see LICENSE for more information";
-                            UIHelper.showMessage(aboutMessage, "About this extension", sharedParameters.get_mainFrame());
-                        }
-                    });
-                    add(mdsecLogoMenu);
-
-                    // fixing the spacing when an icon is used - this used to work fine with old Java
-                    for(var item:getMenuComponents()){
-                        if(item instanceof JMenuItem){
-                            if(((JMenuItem) item).getIcon() == null){
-                                ((JMenuItem) item).setHorizontalTextPosition(SwingConstants.LEFT);
                             }
+                        }).start();
+                    }
+                });
+                add(reloadAllSettings);
+
+                JMenuItem resetAllSettings = new JMenuItem(new AbstractAction("Remove All Settings & Unload") {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        int response = UIHelper.askConfirmMessage("Sharpener Extension: Reset All Settings & Unload", "Are you sure you want to remove all the settings and unload the extension?", new String[]{"Yes", "No"}, sharedParameters.get_mainFrame());
+                        if (response == 0) {
+
+                            // A bug in resetting settings in BurpExtenderUtilities should be fixed so we will give it another chance instead of using a workaround
+                            // sharedParameters.resetAllSettings();
+                            sharedParameters.preferences.resetAllSettings();
+                            sharedParameters.callbacks.unloadExtension();
                         }
                     }
+                });
 
-                }).start();
+                add(resetAllSettings);
+                addSeparator();
+
+                JCheckBoxMenuItem checkForUpdateOption = new JCheckBoxMenuItem("Check for Update on Start");
+                checkForUpdateOption.setToolTipText("Check is done by accessing its GitHub repository");
+                if (sharedParameters.preferences.safeGetBooleanSetting("checkForUpdate")) {
+                    checkForUpdateOption.setSelected(true);
+                }
+
+                checkForUpdateOption.addActionListener((e) -> {
+                    if (sharedParameters.preferences.safeGetBooleanSetting("checkForUpdate")) {
+                        sharedParameters.preferences.safeSetSetting("checkForUpdate", false);
+                    } else {
+                        sharedParameters.preferences.safeSetSetting("checkForUpdate", true);
+                        SharpenerBurpExtender sharpenerBurpExtender = (SharpenerBurpExtender) sharedParameters.burpExtender;
+                        sharpenerBurpExtender.checkForUpdate();
+                    }
+                });
+                add(checkForUpdateOption);
+
+                JMenuItem showProjectPage = new JMenuItem(new AbstractAction("Project Page") {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        new Thread(new Runnable() {
+                            @Override
+                            public void run() {
+                                try {
+                                    Desktop.getDesktop().browse(new URI(sharedParameters.extensionURL));
+                                } catch (Exception e) {
+                                }
+                            }
+                        }).start();
+                    }
+                });
+                showProjectPage.setToolTipText("Will be opened in the default browser");
+                add(showProjectPage);
+
+                JMenuItem reportAnIssue = new JMenuItem(new AbstractAction("Report Bug/Feature") {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        new Thread(new Runnable() {
+                            @Override
+                            public void run() {
+                                try {
+                                    Desktop.getDesktop().browse(new URI(sharedParameters.extensionIssueTracker));
+                                } catch (Exception e) {
+                                }
+                            }
+                        }).start();
+                    }
+                });
+                reportAnIssue.setToolTipText("Will be opened in the default browser");
+                add(reportAnIssue);
+
+                addSeparator();
+
+                Image mdsecLogoImg;
+                if (sharedParameters.isDarkMode) {
+                    mdsecLogoImg = ImageHelper.scaleImageToWidth(ImageHelper.loadImageResource(sharedParameters.extensionClass, "/MDSec-logo-grey.png"), 100);
+                } else {
+                    mdsecLogoImg = ImageHelper.scaleImageToWidth(ImageHelper.loadImageResource(sharedParameters.extensionClass, "/MDSec-logo-blue.png"), 100);
+                }
+                ImageIcon mdsecLogoIcon = new ImageIcon(mdsecLogoImg);
+                JMenuItem mdsecLogoMenu = new JMenuItem(mdsecLogoIcon);
+                mdsecLogoMenu.setPreferredSize(new Dimension(100, 50));
+
+                mdsecLogoMenu.setToolTipText("About this extension");
+                mdsecLogoMenu.addActionListener(new AbstractAction() {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        String aboutMessage = "Burp Suite " + sharedParameters.extensionName + " - version " + sharedParameters.version +
+                                "\nReleased as open source by MDSec - https://www.mdsec.co.uk/\n" +
+                                "Developed by Soroush Dalili (@irsdl)\n" +
+                                "Project link: " + sharedParameters.extensionURL +
+                                "\nReleased under AGPL see LICENSE for more information";
+                        UIHelper.showMessage(aboutMessage, "About this extension", sharedParameters.get_mainFrame());
+                    }
+                });
+                add(mdsecLogoMenu);
+
+                // fixing the spacing when an icon is used - this used to work fine with old Java
+                for (var item : getMenuComponents()) {
+                    if (item instanceof JMenuItem) {
+                        if (((JMenuItem) item).getIcon() == null) {
+                            ((JMenuItem) item).setHorizontalTextPosition(SwingConstants.LEFT);
+                        }
+                    }
+                }
             }
         });
     }
@@ -532,13 +530,11 @@ public class TopMenuBar extends javax.swing.JMenu {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new Thread(() -> {
-                    //removeTopMenuBar(); // this has been disabled as invoke later may mean that the menu may be removed after it is being updated!
-                    removeTopMenuBarLastResort(sharedParameters, true);
-                    sharedParameters.allSettings.mainToolsTabSettings.loadSettings(); // this is to reflect the changes in the UI
-                    topMenuForExtension = new TopMenuBar(sharedParameters);
-                    addTopMenuBar();
-                }).start();
+                //removeTopMenuBar(); // this has been disabled as invoke later may mean that the menu may be removed after it is being updated!
+                removeTopMenuBarLastResort(sharedParameters, true);
+                sharedParameters.allSettings.mainToolsTabSettings.loadSettings(); // this is to reflect the changes in the UI
+                topMenuForExtension = new TopMenuBar(sharedParameters);
+                addTopMenuBar();
             }
         });
     }
@@ -547,38 +543,41 @@ public class TopMenuBar extends javax.swing.JMenu {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new Thread(() -> {
-                    try {
-                        // adding toolbar
-                        JMenuBar menuBar = sharedParameters.get_mainMenuBar();
-                        if (topMenuForExtension == null) {
-                            topMenuForExtension = new TopMenuBar(sharedParameters);
-                        }
-                        //menuBar.add(topMenuForExtension, menuBar.getMenuCount() - 1);
-                        // to make it bold
-                        topMenuForExtension.setFont(topMenuForExtension.getFont().deriveFont(topMenuForExtension.getFont().getStyle() ^ Font.BOLD));
-                        menuBar.add(topMenuForExtension, 5); // we are adding this just after menu `Window`
-                        //sharedParameters.get_mainFrame().revalidate();
-                        //sharedParameters.get_mainMenuBar().repaint();
-                        // to set back to plain after a few seconds
-
-                        new java.util.Timer().schedule(
-                                new java.util.TimerTask() {
-                                    @Override
-                                    public void run() {
-                                        //topMenuForExtension.setFont(topMenuForExtension.getFont().deriveFont(topMenuForExtension.getFont().getStyle() ^ Font.BOLD)); // this would set the font so if we change them later in the UI, this menu will not be updated!
-                                        topMenuForExtension.setFont(UIManager.getLookAndFeelDefaults().getFont(topMenuForExtension.getComponent()));
-                                    }
-                                },
-                                2000
-                        );
-                    } catch (Exception e) {
-                        sharedParameters.stderr.println("Error in adding the top menu: " + e.getMessage());
+                try {
+                    // adding toolbar
+                    JMenuBar menuBar = sharedParameters.get_mainMenuBar();
+                    if (topMenuForExtension == null) {
+                        topMenuForExtension = new TopMenuBar(sharedParameters);
                     }
-                }).start();
+                    //menuBar.add(topMenuForExtension, menuBar.getMenuCount() - 1);
+                    // to make it bold
+                    topMenuForExtension.setFont(topMenuForExtension.getFont().deriveFont(topMenuForExtension.getFont().getStyle() ^ Font.BOLD));
+                    menuBar.add(topMenuForExtension, 5); // we are adding this just after menu `Window`
+                    // Revalidate helps ensure the menubar picks up our change
+                    menuBar.revalidate();
+                    //sharedParameters.get_mainFrame().revalidate();
+                    //sharedParameters.get_mainMenuBar().repaint();
+                    // to set back to plain after a few seconds
+                    new java.util.Timer().schedule(
+                            new java.util.TimerTask() {
+                                @Override
+                                public void run() {
+                                    SwingUtilities.invokeLater(new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            //topMenuForExtension.setFont(topMenuForExtension.getFont().deriveFont(topMenuForExtension.getFont().getStyle() ^ Font.BOLD)); // this would set the font so if we change them later in the UI, this menu will not be updated!
+                                            topMenuForExtension.setFont(UIManager.getLookAndFeelDefaults().getFont(topMenuForExtension.getComponent()));
+                                        }
+                                    });
+                                }
+                            },
+                            2000
+                    );
+                } catch (Exception e) {
+                    sharedParameters.stderr.println("Error in adding the top menu: " + e.getMessage());
+                }
             }
         });
-
     }
 
     public static void removeTopMenuBarLastResort(SharpenerSharedParameters sharedParameters, boolean repaintUI) {
@@ -597,19 +596,17 @@ public class TopMenuBar extends javax.swing.JMenu {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                new Thread(() -> {
-                    try {
-                        // removing old toolbar
-                        sharedParameters.get_mainMenuBar().remove(topMenuForExtension);
-                    } catch (Exception e) {
-                        sharedParameters.stderr.println("Error in removing the top menu: " + e.getMessage());
-                    }
-                    // just in case the above did not work
-                    removeTopMenuBarLastResort(sharedParameters, false);
+                try {
+                    // removing old toolbar
+                    sharedParameters.get_mainMenuBar().remove(topMenuForExtension);
+                } catch (Exception e) {
+                    sharedParameters.stderr.println("Error in removing the top menu: " + e.getMessage());
+                }
+                // just in case the above did not work
+                removeTopMenuBarLastResort(sharedParameters, false);
 
-                    sharedParameters.get_mainMenuBar().revalidate();
-                    sharedParameters.get_mainMenuBar().repaint();
-                }).start();
+                sharedParameters.get_mainMenuBar().revalidate();
+                sharedParameters.get_mainMenuBar().repaint();
             }
         });
     }


### PR DESCRIPTION
This PR fixes problems described in issue #72

- do not spawn new threads for executing GUI operations
- call `invokeLater()` inside scheduled tasks
- call `revalidate()` for the top menu bar and tool tab styling to ensure GUI items are in sync.

This completely resolved the issue for me, and also seems to have made the interface faster and mores responsive.

Completed the following tests with no issues:

✔️ Loaded/unloaded extensions
✔️ Added/removed tool tab icon themes
✔️ Detached/re-attached tool windows (styling is reset correctly when re-attached)
✔️ Re-organized tool tabs (drag and drop)
✔️ Set custom styling sub-tab styling (repeater and intruder)
✔️ Filtered/unfiltered sub-tabs based on regex
✔️ Set custom project title and icon

Tested on Burp Suite Professional v2022.3.7 (Windows 10 and Kali-Linux)

Please let me know if there's any other specific testing you'd like to see.